### PR TITLE
Sets up the pipe before resuming the input stream

### DIFF
--- a/ftp.js
+++ b/ftp.js
@@ -270,8 +270,8 @@ FTP.prototype.put = function(instream, destpath, cb) {
 
     var r = self.send('STOR', destpath, cb);
     if (r) {
-      instream.resume();
       instream.pipe(outstream); 
+      instream.resume();
     }                                 
     else
       cb(new Error('Connection severed'));


### PR DESCRIPTION
Let me know if there's  reason why this is incorrect behavior?
