### PR TITLE
Fixed issue with .rename

### DIFF
--- a/lib/ftp.js
+++ b/lib/ftp.js
@@ -341,7 +341,7 @@ FTP.prototype.status = function(cb) {
 
 FTP.prototype.rename = function(from, to, cb) {
   var self = this;
-  this._send('RNFR' + from, function(err) {
+  this._send('RNFR ' + from, function(err) {
     if (err)
       return cb(err);
 


### PR DESCRIPTION
I believe I found a typo in the implementation of .rename. As it was it resulted in a 500 error from the server.
