### PR TITLE
Handle return code 125 for RETR command

### DIFF
--- a/lib/ftp.js
+++ b/lib/ftp.js
@@ -555,7 +555,9 @@ FTP.prototype.get = function(path, zcomp, cb) {
           }
           return;
         }
-        if (code === 150) {
+        // server returns 125 when data connection is already open; we treat it
+        // just like a 150
+        if (code === 150 || code === 125) {
           started = true;
           cb(undefined, source);
           sock.resume();


### PR DESCRIPTION
While working with a particular FTP server, the server returned 125 instead of 150 while getting a file in response to the RETR command. Turns out that's a valid response code as well. Allowing the response processing code for RETR to handle 125 as well moves things along nicely - otherwise the code just waits indefinitely for a 150 to show up which never comes.
