### PR TITLE
Updated connection.js to allow for self signed cert

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -74,7 +74,8 @@ var FTP = module.exports = function() {
     secure: false,
     connTimeout: undefined,
     pasvTimeout: undefined,
-    aliveTimeout: undefined
+    aliveTimeout: undefined,
+    rejectUnauthorized: true
   };
   this.connected = false;
 };
@@ -93,7 +94,8 @@ FTP.prototype.connect = function(options) {
   this.options.connTimeout = options.connTimeout || 10000;
   this.options.pasvTimeout = options.pasvTimeout || 10000;
   this.options.aliveTimeout = options.keepalive || 10000;
-
+  this.options.rejectUnauthorized = options.rejectUnauthorized !== false;
+  
   if (typeof options.debug === 'function')
     this._debug = options.debug;
 
@@ -126,7 +128,7 @@ FTP.prototype.connect = function(options) {
 
   this._socket.setTimeout(0);
   if (this.options.secure === 'implicit')
-    socket = tls.connect({ socket: this._socket }, onconnect);
+    socket = tls.connect({ socket: this._socket, rejectUnauthorized: this.options.rejectUnauthorized }, onconnect);
   else
     this._socket.once('connect', onconnect);
 


### PR DESCRIPTION
Exposed rejectUnauthorized from tls as an option for the connect method in node-ftp. 

I had a self-signed cert for testing on my local machine. I was getting Error: DEPTH_ZERO_SELF_SIGNED_CERT. I modified the options object for the connect method to expose the rejectUnauthorized option for tls.
