### PR TITLE
Fix connection.js for use in strict mode

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -667,7 +667,7 @@ FTP.prototype.mkdir = function(path, recursive, cb) { // MKD is optional
     if (path.indexOf('/') === -1)
       this._send('MKD ' + path, cb);
     else {
-      function nextDir() {
+      var nextDir = function() {
         if (++i === dirslen) {
           // return to original working directory
           return self._send('CWD ' + owd, cb, true);


### PR DESCRIPTION
When running node with `--use_strict` one gets this error:

```
node_modules/ftp/lib/connection.js:650
  function nextDir() {
  ^^^^^^^^
SyntaxError: In strict mode code, functions can only be declared at top level or immediately within another function.
```
