### PR TITLE
Parser: better year parsing on *NIX lists

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -110,26 +110,25 @@ Parser.parseListEntry = function(line) {
         mins = '0' + mins;
       info.date = new Date(year + '-' + month + '-' + day + 'T'
                            + hour + ':' + mins);
-      // if the date is in the past but not older than 6 months ago, year
-      // isn't displayed and doesn't have to be the current year
+      // If the date is in the past but no more than 6 months old, year
+      // isn't displayed and doesn't have to be the current year.
       // 
-      // if the date is in the future (less than an hour from now), year
-      // isn't displayed and doesn't have to be the current year (if it's
-      // December 31st 23:30 for instance).
+      // If the date is in the future (less than an hour from now), year
+      // isn't displayed and doesn't have to be the current year.
       // That second case is much more rare than the first and less annoying.
       // It's impossible to fix without knowing about the server's timezone,
       // so we just don't do anything about it.
       // 
-      // if we're here with a date 28 hours from now in the future (1 hour +
-      // maximum timezone offset which is 27 hours),
+      // If we're here with a time that is more than 28 hours into the
+      // future (1 hour + maximum timezone offset which is 27 hours),
       // there is a problem : we should be in the second conditional block
       if(info.date.getTime()-new Date().getTime() > 100800000)
         info.date = new Date((year-1) + '-' + month + '-' + day + 'T'
                              + hour + ':' + mins);
 
-      // if we're here with a date older than 6 months in the past, there's
-      // a problem as well
-      // maybe local & remote servers aren't on the same timezone (with remote
+      // If we're here with a time that is more than 6 months old, there's
+      // a problem as well.
+      // Maybe local & remote servers aren't on the same timezone (with remote
       // ahead of local)
       // For instance, remote is in 2014 while local is still in 2013. In
       // this case, a date like 01/01/13 02:23 could be detected instead of


### PR DESCRIPTION
When getting a *NIX-like list, the library is using the local machine's current year to guess the modification date of a directory/file which can be wrong.

Even though FTP's lists are a mess, most of them seem to be using the ls behavior:
`For files with a time that is more than 6 months old or more than 1 hour into the future, the timestamp contains the year instead of the time of day.`

Because of the lack of timezone support in the FTP standards, it's not always possible to guess the right year, but it's possible to improve the guess.

This patch wasn't fully tested.

I've put lots of comments (because I needed them - dealing with dates + timezones can get complicated), feel free to get rid of them.
