### PR TITLE
fix mkdir with relative path in root dir

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -663,59 +663,56 @@ FTP.prototype.mkdir = function(path, recursive, cb) { // MKD is optional
     var self = this, owd, abs, dirs, dirslen, i = -1, searching = true;
 
     abs = (path[0] === '/');
-    if (path.indexOf('/') === -1)
-      this._send('MKD ' + path, cb);
-    else {
-      var nextDir = function() {
-        if (++i === dirslen) {
-          // return to original working directory
-          return self._send('CWD ' + owd, cb, true);
-        }
-        if (searching) {
-          self._send('CWD ' + dirs[i], function(err, text, code) {
-            if (code === 550) {
-              searching = false;
-              --i;
-            } else if (err) {
-              // return to original working directory
-              return self._send('CWD ' + owd, function() {
-                cb(err);
-              }, true);
-            }
-            nextDir();
-          }, true);
-        } else {
-          self._send('MKD ' + dirs[i], function(err, text, code) {
-            if (err) {
-              // return to original working directory
-              return self._send('CWD ' + owd, function() {
-                cb(err);
-              }, true);
-            }
-            self._send('CWD ' + dirs[i], nextDir, true);
-          }, true);
-        }
-      };
-      this.pwd(function(err, cwd) {
-        if (err)
-          return cb(err);
-        owd = cwd;
-        if (abs)
-          path = path.substr(1);
-        if (path[path.length - 1] === '/')
-          path = path.substring(0, path.length - 1);
-        dirs = path.split('/');
-        dirslen = dirs.length;
-        if (abs)
-          self._send('CWD /', function(err) {
-            if (err)
-              return cb(err);
-            nextDir();
-          }, true);
-        else
+
+    var nextDir = function() {
+      if (++i === dirslen) {
+        // return to original working directory
+        return self._send('CWD ' + owd, cb, true);
+      }
+      if (searching) {
+        self._send('CWD ' + dirs[i], function(err, text, code) {
+          if (code === 550) {
+            searching = false;
+            --i;
+          } else if (err) {
+            // return to original working directory
+            return self._send('CWD ' + owd, function() {
+              cb(err);
+            }, true);
+          }
           nextDir();
-      });
-    }
+        }, true);
+      } else {
+        self._send('MKD ' + dirs[i], function(err, text, code) {
+          if (err) {
+            // return to original working directory
+            return self._send('CWD ' + owd, function() {
+              cb(err);
+            }, true);
+          }
+          self._send('CWD ' + dirs[i], nextDir, true);
+        }, true);
+      }
+    };
+    this.pwd(function(err, cwd) {
+      if (err)
+        return cb(err);
+      owd = cwd;
+      if (abs)
+        path = path.substr(1);
+      if (path[path.length - 1] === '/')
+        path = path.substring(0, path.length - 1);
+      dirs = path.split('/');
+      dirslen = dirs.length;
+      if (abs)
+        self._send('CWD /', function(err) {
+          if (err)
+            return cb(err);
+          nextDir();
+        }, true);
+      else
+        nextDir();
+    });
   }
 };
 


### PR DESCRIPTION
fix #80
For the special case - relative path, in the root directory -, we send a MKD cmd without to check if the directory already exists.
I suggest to not consider this case as a special case, and directly enter in the recursive loop, which check if the directory exists before to send MKD cmd.
