### PR TITLE
Make it possible to use an empty string as the password

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -89,8 +89,7 @@ FTP.prototype.connect = function(options) {
   this.options.port = options.port || 21;
   this.options.user = options.user || 'anonymous';
   this.options.password = options.password ||
-      options.password === ''
-      ? options.password
+      options.password === '' ? options.password
       : 'anonymous@';
   this.options.secure = options.secure || false;
   this.options.secureOptions = options.secureOptions;

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -88,7 +88,10 @@ FTP.prototype.connect = function(options) {
   this.options.host = options.host || 'localhost';
   this.options.port = options.port || 21;
   this.options.user = options.user || 'anonymous';
-  this.options.password = options.password || 'anonymous@';
+  this.options.password = options.password ||
+      options.password === ''
+      ? options.password
+      : 'anonymous@';
   this.options.secure = options.secure || false;
   this.options.secureOptions = options.secureOptions;
   this.options.connTimeout = options.connTimeout || 10000;
@@ -215,7 +218,8 @@ FTP.prototype.connect = function(options) {
       } else if (cmd === 'USER') {
         /*if (code === 331) {
           // password required
-          if (!self.options.password) {
+          if (!self.options.password &&
+               self.options.password !== '') {
             self.emit('error', makeError(code, 'Password required'));
             return self._socket && self._socket.end();
           }


### PR DESCRIPTION
The module was unusable because the ftp server I was trying to access insisted on a password of zero length. This pull request fixes that while preserving the behavior of a falsy password in the options.
