### PR TITLE
store: call callback on socket error.

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -968,6 +968,7 @@ FTP.prototype._store = function(cmd, input, zcomp, cb) {
     var sockerr, dest = sock;
     sock.once('error', function(err) {
       sockerr = err;
+      cb(err);
     });
 
     if (zcomp) {


### PR DESCRIPTION
Hello,
When a socket error happens during an STOR or APPE, this error doesn't seem to propagate to the callback passed to put() or append(). I believe a single call to cb should be added in the socket error handler. At least, it solves the issue I have at hand. 
Can you verify this?
Thanks.