### PR TITLE
Put fs on its own line

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -1,5 +1,5 @@
-var fs = require('fs'),
-    tls = require('tls'),
+var fs = require('fs');
+var tls = require('tls'),
     zlib = require('zlib'),
     Socket = require('net').Socket,
     EventEmitter = require('events').EventEmitter,


### PR DESCRIPTION
Due to the way the brfs transform works, I was having a breaking error with fs being part of a multiple variable definition (see [this](https://github.com/substack/brfs/issues/28). This change fixes it.