### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,6 @@
     "test": "node test/test.js"
   },
   "keywords": [ "ftp", "client", "transfer" ],
-  "licenses": [ { "type": "MIT", "url": "http://github.com/mscdex/node-ftp/raw/master/LICENSE" } ],
+  "license": "MIT",
   "repository" : { "type": "git", "url": "http://github.com/mscdex/node-ftp.git" }
 }


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/