### PR TITLE
fix for #70

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -562,8 +562,8 @@ FTP.prototype.get = function(path, zcomp, cb) {
         if (!done) {
           done = true;
           ondone();
+          return;
         }
-        return;
       }
       source._emit.apply(source, Array.prototype.slice.call(arguments));
     };
@@ -614,8 +614,8 @@ FTP.prototype.get = function(path, zcomp, cb) {
         // just like a 150
         if (code === 150 || code === 125) {
           started = true;
-          cb(undefined, source);
           sock.resume();
+          cb(undefined, source);
         } else {
           lastreply = true;
           ondone();


### PR DESCRIPTION
https://github.com/mscdex/node-ftp/issues/70
- call resume before the callback so that consumers can use pause() as expected
- send end event when data is consumed after a get
