### PR TITLE
add i18n support

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -65,6 +65,7 @@ var FTP = module.exports = function() {
   this._keepalive = undefined;
   this._ending = false;
   this._parser = undefined;
+  this._utf8 = false;
   this.options = {
     host: undefined,
     port: undefined,
@@ -230,8 +231,20 @@ FTP.prototype.connect = function(options) {
         cmd = 'FEAT';
         self._send(cmd, reentry, true);
       } else if (cmd === 'FEAT') {
-        if (!err)
+        if (!err) {
           self._feat = Parser.parseFeat(text);
+          self._utf8 = self._feat.indexOf('UTF8')>=0 // RFC #2640
+        }
+        if (self._utf8) {
+          // required by MS IIS 7.x FTP implementation which think based on
+          // http://tools.ietf.org/html/draft-ietf-ftpext-utf-8-option-00
+          cmd = 'OPTS';
+          self._send('OPTS UTF8 ON', reentry, true);
+        } else {
+          cmd = 'TYPE';
+          self._send('TYPE I', reentry, true);
+        }
+      } else if (cmd === 'OPTS') { // ignore OPTS UTF8 result
         cmd = 'TYPE';
         self._send('TYPE I', reentry, true);
       } else if (cmd === 'TYPE')
@@ -438,7 +451,9 @@ FTP.prototype.list = function(path, zcomp, cb) {
       sock.pipe(source);
     }
 
-    source.on('data', function(chunk) { buffer += chunk.toString('binary'); });
+    source.on('data', function(chunk) {
+      buffer += chunk.toString(self._utf8 ? 'utf8' : 'binary');
+    });
     source.once('error', function(err) {
       if (!sock.aborting)
         sockerr = err;


### PR DESCRIPTION
According chapter "Conflicting specification" from https://wiki.filezilla-project.org/Character_Set
fixed #84

Required for MS IIS 7.x FTP to use LIST with utf8
