### PR TITLE
test: Fix test cases for timeZone difference

### DIFF
--- a/test/test-parser.js
+++ b/test/test-parser.js
@@ -19,7 +19,7 @@ var group = path.basename(__filename, '.js') + '/';
       owner: 'root',
       group: 'root',
       size: 4096,
-      date: new Date('2012-12-21T00:00')
+      date: new Date('2012-12-21T00:00Z')
     },
     what: 'Normal directory'
   },
@@ -34,7 +34,7 @@ var group = path.basename(__filename, '.js') + '/';
       owner: 'owner',
       group: 'group',
       size: 0,
-      date: new Date('2012-08-31T00:00')
+      date: new Date('2012-08-31T00:00Z')
     },
     what: 'Normal directory #2'
   },
@@ -49,7 +49,7 @@ var group = path.basename(__filename, '.js') + '/';
       owner: 'owner',
       group: 'group',
       size: 7045120,
-      date: new Date('2012-09-02T00:00')
+      date: new Date('2012-09-02T00:00Z')
     },
     what: 'Normal file'
   },
@@ -64,7 +64,7 @@ var group = path.basename(__filename, '.js') + '/';
       owner: 'owner',
       group: 'group',
       size: 7045120,
-      date: new Date('2012-09-02T00:00')
+      date: new Date('2012-09-02T00:00Z')
     },
     what: 'File with ACL set'
   },
@@ -79,7 +79,7 @@ var group = path.basename(__filename, '.js') + '/';
       owner: 'root',
       group: 'root',
       size: 4096,
-      date: new Date('2012-05-19T00:00')
+      date: new Date('2012-05-19T00:00Z')
     },
     what: 'Directory with sticky bit and executable for others'
   },
@@ -94,7 +94,7 @@ var group = path.basename(__filename, '.js') + '/';
       owner: 'root',
       group: 'root',
       size: 4096,
-      date: new Date('2012-05-19T00:00')
+      date: new Date('2012-05-19T00:00Z')
     },
     what: 'Directory with sticky bit and executable for others #2'
   },
@@ -109,7 +109,7 @@ var group = path.basename(__filename, '.js') + '/';
       owner: 'root',
       group: 'root',
       size: 4096,
-      date: new Date('2012-05-19T00:00')
+      date: new Date('2012-05-19T00:00Z')
     },
     what: 'Directory with sticky bit and not executable for others'
   },
@@ -124,7 +124,7 @@ var group = path.basename(__filename, '.js') + '/';
       owner: 'root',
       group: 'root',
       size: 4096,
-      date: new Date('2012-05-19T00:00')
+      date: new Date('2012-05-19T00:00Z')
     },
     what: 'Directory with sticky bit and not executable for others #2'
   },


### PR DESCRIPTION
`test-parser.js` expects `Date` fields of files/directory to match with
whatever specified in test case. However the expected date/time values
doesn't specify timezone.

Here is what [ES6 spec](http://www.ecma-international.org/ecma-262/6.0/#sec-date-time-string-format) says regaring missing timeZone.

``` doc
If the time zone offset is absent, the date-time is interpreted as a local time.
```

On the other hand, the information returned by `parseListEntry()` is alway in `UTC`.
See ES6 spec for [Date constructor](http://www.ecma-international.org/ecma-262/6.0/#sec-date-year-month-date-hours-minutes-seconds-ms)

Hence if someone running test cases in timeZone other than UTC will always see mismatch
in timeZone as the actual date returned would be in UTC, while expected date would
be in UTC equivalent of datetime specified in `expected` property.

This issue has not surfaced in node+v8 because if timeZone is missing, it is
interpreted as UTC.

A quick test can verify this is FF nightly / Edge / Chrome

``` js
var x = new Date('2012-12-21T00:00:00.000');
x.toISOString();

// For PST timezone, this should be "2012-12-21T08:00:00.000Z" and not "2012-12-21T00:00:00.000Z". 

```
