### PR TITLE
Support return code 200 for authentication

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -247,7 +247,7 @@ FTP.prototype.connect = function(options) {
         cmd = 'USER';
         self._send('USER ' + self.options.user, reentry, true);
       } else if (cmd.substr(0, 4) === 'AUTH') {
-        if (cmd === 'AUTH TLS' && code !== 234) {
+        if (cmd === 'AUTH TLS' && (code !== 234 || code !== 200)) {
           cmd = 'AUTH SSL';
           return self._send(cmd, reentry, true);
         } else if (cmd === 'AUTH TLS')


### PR DESCRIPTION
VxWorks FTP Server is used in many embedded devices and returns 200 (not 234) when accepting authentication using “AUTH TLS” or “AUTH SSL”. The current version of node-ftp doesn't handle this case and will hang.

This pull request will accept a return code of 200. Here is an example with VxWorks FTP Server:

```
[connection] < '220 VxWorks FTP server (VxWorks VxWorks5.5.1) ready.\r\n'
[parser] < '220 VxWorks FTP server (VxWorks VxWorks5.5.1) ready.\r\n'
[parser] Response: code=220, buffer='VxWorks FTP server (VxWorks VxWorks5.5.1) ready.'
[connection] > 'AUTH TLS'
[connection] < '200 AUTH command ok; starting SSL connection...\r\n'
[parser] < '200 AUTH command ok; starting SSL connection...\r\n'
[parser] Response: code=200, buffer='AUTH command ok; starting SSL connection...'
```

According to [this list of FTP server return codes](https://en.wikipedia.org/wiki/List_of_FTP_server_return_codes), the return code 234 is nonstandard anyway which was surprising to me. Maybe that will make it easier for node-ftp to accept 200 as well?