### PR TITLE
Bugfix: Use original socket to connect when using 'implicit' secure mode

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -141,11 +141,11 @@ FTP.prototype.connect = function(options) {
     this.options.secureOptions = secureOptions;
   }
 
+  this._socket = socket;
   if (this.options.secure === 'implicit')
-    this._socket = tls.connect(secureOptions, onconnect);
+    socket = tls.connect(secureOptions, onconnect);
   else {
     socket.once('connect', onconnect);
-    this._socket = socket;
   }
 
   var noopreq = {


### PR DESCRIPTION
Currently, implicit FTPS mode is broken.

When using implicit FTPS, the current code assigns the returned socket from `tls.connect` to `this._socket`, which is used to make the initial connection.

The problem is that the TLSSocket expects the original socket passed in to make the connection.  Since it doesn't, the socket never actually connects and it always ends in a timeout.

I ran into this with a client this past week, and there's a [StackOverflow question](http://stackoverflow.com/questions/41221050/how-to-connect-to-a-implicit-ftps-server-with-nodejs) that is unanswered regarding this same problem.  It appears there are no tests for connecting, but I've verified that I'm able to connect to our client's implicit FTPS server with this change.

