### PR TITLE
Connection: Add option to specify keep-alive behaviour on connect.

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -75,7 +75,8 @@ var FTP = module.exports = function() {
     secureOptions: undefined,
     connTimeout: undefined,
     pasvTimeout: undefined,
-    aliveTimeout: undefined
+    aliveTimeout: undefined,
+    keepAlive: undefined
   };
   this.connected = false;
 };
@@ -97,6 +98,7 @@ FTP.prototype.connect = function(options) {
   this.options.connTimeout = options.connTimeout || 10000;
   this.options.pasvTimeout = options.pasvTimeout || 10000;
   this.options.aliveTimeout = options.keepalive || 10000;
+  this.options.keepAlive = options.keepAlive || false;
 
   if (typeof options.debug === 'function')
     this._debug = options.debug;
@@ -106,7 +108,7 @@ FTP.prototype.connect = function(options) {
       socket = new Socket();
 
   socket.setTimeout(0);
-  socket.setKeepAlive(true);
+  socket.setKeepAlive(this.options.keepAlive);
 
   this._parser = new Parser({ debug: debug });
   this._parser.on('response', function(code, text) {
@@ -743,12 +745,12 @@ FTP.prototype.rmdir = function(path, recursive, cb) { // RMD is optional
   if (!recursive) {
     return this._send('RMD ' + path, cb);
   }
-  
+
   var self = this;
   this.list(path, function(err, list) {
     if (err) return cb(err);
     var idx = 0;
-    
+
     // this function will be called once per listing entry
     var deleteNextEntry;
     deleteNextEntry = function(err) {
@@ -760,9 +762,9 @@ FTP.prototype.rmdir = function(path, recursive, cb) { // RMD is optional
           return self.rmdir(path, cb);
         }
       }
-      
+
       var entry = list[idx++];
-      
+
       // get the path to the file
       var subpath = null;
       if (entry.name[0] === '/') {
@@ -776,7 +778,7 @@ FTP.prototype.rmdir = function(path, recursive, cb) { // RMD is optional
           subpath = path + '/' + entry.name
         }
       }
-      
+
       // delete the entry (recursively) according to its type
       if (entry.type === 'd') {
         if (entry.name === "." || entry.name === "..") {

--- a/lib/connection.js
+++ b/lib/connection.js
@@ -323,6 +323,10 @@ FTP.prototype.end = function() {
 };
 
 FTP.prototype.destroy = function() {
+  if (this._pasvSock && this._pasvSock.writable)
+    this._pasvSock.destroy();
+  if (this._socket && this._socket.writable)
+    this._socket.destroy();
   this._reset();
 };
 

--- a/test/test-parser.js
+++ b/test/test-parser.js
@@ -19,7 +19,7 @@ var group = path.basename(__filename, '.js') + '/';
       owner: 'root',
       group: 'root',
       size: 4096,
-      date: new Date('2012-12-21T00:00')
+      date: new Date('2012-12-21T00:00Z')
     },
     what: 'Normal directory'
   },
@@ -34,7 +34,7 @@ var group = path.basename(__filename, '.js') + '/';
       owner: 'owner',
       group: 'group',
       size: 0,
-      date: new Date('2012-08-31T00:00')
+      date: new Date('2012-08-31T00:00Z')
     },
     what: 'Normal directory #2'
   },
@@ -49,7 +49,7 @@ var group = path.basename(__filename, '.js') + '/';
       owner: 'owner',
       group: 'group',
       size: 7045120,
-      date: new Date('2012-09-02T00:00')
+      date: new Date('2012-09-02T00:00Z')
     },
     what: 'Normal file'
   },
@@ -64,7 +64,7 @@ var group = path.basename(__filename, '.js') + '/';
       owner: 'owner',
       group: 'group',
       size: 7045120,
-      date: new Date('2012-09-02T00:00')
+      date: new Date('2012-09-02T00:00Z')
     },
     what: 'File with ACL set'
   },
@@ -79,7 +79,7 @@ var group = path.basename(__filename, '.js') + '/';
       owner: 'root',
       group: 'root',
       size: 4096,
-      date: new Date('2012-05-19T00:00')
+      date: new Date('2012-05-19T00:00Z')
     },
     what: 'Directory with sticky bit and executable for others'
   },
@@ -94,7 +94,7 @@ var group = path.basename(__filename, '.js') + '/';
       owner: 'root',
       group: 'root',
       size: 4096,
-      date: new Date('2012-05-19T00:00')
+      date: new Date('2012-05-19T00:00Z')
     },
     what: 'Directory with sticky bit and executable for others #2'
   },
@@ -109,7 +109,7 @@ var group = path.basename(__filename, '.js') + '/';
       owner: 'root',
       group: 'root',
       size: 4096,
-      date: new Date('2012-05-19T00:00')
+      date: new Date('2012-05-19T00:00Z')
     },
     what: 'Directory with sticky bit and not executable for others'
   },
@@ -124,7 +124,7 @@ var group = path.basename(__filename, '.js') + '/';
       owner: 'root',
       group: 'root',
       size: 4096,
-      date: new Date('2012-05-19T00:00')
+      date: new Date('2012-05-19T00:00Z')
     },
     what: 'Directory with sticky bit and not executable for others #2'
   },


### PR DESCRIPTION
At one of our customers with a DELL Sonic firewall, the FTP connection would be dropped when keep-alives are enabled. This pull request adds an option to specify the keep-alive behaviour of the FTP connection and defaults to the safe option of disabling it.