### PR TITLE
Fix UTF-8 characters problem

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -475,8 +475,9 @@ FTP.prototype.list = function(path, zcomp, cb) {
         var parsed = [];
         for (var i = 0, len = entries.length; i < len; ++i) {
           var parsedVal = Parser.parseListEntry(entries[i]);
-          if (parsedVal !== null)
-            parsed.push(parsedVal);
+          if (parsedVal === null) continue;
+          parsedVal.name = decodeURIComponent(escape(parsedVal.name)); // Decode UTF-8
+          parsed.push(parsedVal);
         }
 
         if (zcomp) {


### PR DESCRIPTION
When a string with characters like "ğ" are passed on name of file, all functions with this.list (using entry.name) don't work (rmdir for example).
- Added UTF-8 decode logic.