### PR TITLE
Fix list parse failing when encountering the S file mode bit - Issue #223

### DIFF
--- a/lib/parser.js
+++ b/lib/parser.js
@@ -5,7 +5,7 @@ var WritableStream = require('stream').Writable
 
 var XRegExp = require('xregexp').XRegExp;
 
-var REX_LISTUNIX = XRegExp.cache('^(?<type>[\\-ld])(?<permission>([\\-r][\\-w][\\-xstT]){3})(?<acl>(\\+))?\\s+(?<inodes>\\d+)\\s+(?<owner>\\S+)\\s+(?<group>\\S+)\\s+(?<size>\\d+)\\s+(?<timestamp>((?<month1>\\w{3})\\s+(?<date1>\\d{1,2})\\s+(?<hour>\\d{1,2}):(?<minute>\\d{2}))|((?<month2>\\w{3})\\s+(?<date2>\\d{1,2})\\s+(?<year>\\d{4})))\\s+(?<name>.+)$'),
+var REX_LISTUNIX = XRegExp.cache('^(?<type>[\\-ld])(?<permission>([\\-r][\\-w][\\-xsStT]){3})(?<acl>(\\+))?\\s+(?<inodes>\\d+)\\s+(?<owner>\\S+)\\s+(?<group>\\S+)\\s+(?<size>\\d+)\\s+(?<timestamp>((?<month1>\\w{3})\\s+(?<date1>\\d{1,2})\\s+(?<hour>\\d{1,2}):(?<minute>\\d{2}))|((?<month2>\\w{3})\\s+(?<date2>\\d{1,2})\\s+(?<year>\\d{4})))\\s+(?<name>.+)$'),
     REX_LISTMSDOS = XRegExp.cache('^(?<month>\\d{2})(?:\\-|\\/)(?<date>\\d{2})(?:\\-|\\/)(?<year>\\d{2,4})\\s+(?<hour>\\d{2}):(?<minute>\\d{2})\\s{0,1}(?<ampm>[AaMmPp]{1,2})\\s+(?:(?<size>\\d+)|(?<isdir>\\<DIR\\>))\\s+(?<name>.+)$'),
     RE_ENTRY_TOTAL = /^total/,
     RE_RES_END = /(?:^|\r?\n)(\d{3}) [^\r\n]*\r?\n/,


### PR DESCRIPTION
Pull request to fix #223.

A server I tried to connect to has a directory with the S file mode bit set, node-ftp is currently unable to parse any line which contains that bit. According to the [ls manual](https://www.gnu.org/software/coreutils/manual/html_node/What-information-is-listed.html#index-permissions_002c-output-by-ls) S is a valid file mode bit which means:

> If the set-user-ID or set-group-ID bit is set but the corresponding executable bit is not set.

This pull request adds the S bit to the regex.