### PR TITLE
Update connection.js

### DIFF
--- a/lib/connection.js
+++ b/lib/connection.js
@@ -50,7 +50,7 @@ var /*TYPE = {
       552: 'Requested file action aborted / Exceeded storage allocation (for current directory or dataset)',
       553: 'Requested action not taken / File name not allowed'
     },*/
-    bytesNOOP = new Buffer('NOOP\r\n');
+    bytesNOOP = Buffer.from('NOOP\r\n');
 
 var FTP = module.exports = function() {
   if (!(this instanceof FTP))


### PR DESCRIPTION
Switched out deprecated Buffer constructor.

Traced from "Pointer not aligned" exceptions during fork()s in node-webkit, via proxy-agent => proxy-pac-agent => get-uri => ftp