### PR TITLE
Describe remote server connection on examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,12 @@ Examples
       stream.pipe(fs.createWriteStream('foo.local-copy.txt'));
     });
   });
-  // connect to localhost:21 as anonymous
-  c.connect();
+  // connect to a remote server
+  c.connect({
+    host: '',
+    password: '',
+    user: ''
+  });
 ```
 
 * Upload local file 'foo.txt' to the server:


### PR DESCRIPTION
This changes avoid basic issues like this: https://github.com/mscdex/node-ftp/issues/273

It's more common to use this library to connect to a remote server instead of a local server, I guess 👍 